### PR TITLE
Api provides an endpoint to delete a recipe

### DIFF
--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -1,5 +1,5 @@
 class Api::RecipesController < ApplicationController
-  before_action :authenticate_user!, only: [:create]
+  before_action :authenticate_user!, only: %i[create destroy]
   before_action :validate_params_presence, only: [:create]
   before_action :find_recipe, only: %i[show update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_404_error
@@ -30,6 +30,10 @@ class Api::RecipesController < ApplicationController
     else
       render_error(recipe.errors.full_messages.to_sentence, 422)
     end
+  end
+
+  def destroy
+    Recipe.delete_by(id: params[:id])
   end
 
   private

--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -36,7 +36,7 @@ class Api::RecipesController < ApplicationController
     if Recipe.delete_by(id: params[:id]) == 1
       render json: { message: 'Your recipe has been deleted!' }, status: 202
     else
-      render_error('The recipe cannot be found', :not_found)
+      render_404_error
     end
   end
 

--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -33,7 +33,11 @@ class Api::RecipesController < ApplicationController
   end
 
   def destroy
-    Recipe.delete_by(id: params[:id])
+    if Recipe.delete_by(id: params[:id]) == 1
+      render json: { message: 'Your recipe has been deleted!' }, status: 202
+    else
+      render_error('The recipe cannot be found', :not_found)
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
-    resources :recipes, only: %i[index show create update]
+    resources :recipes, only: %i[index show create update destroy]
   end
 end

--- a/spec/requests/api/recipes/delete_spec.rb
+++ b/spec/requests/api/recipes/delete_spec.rb
@@ -1,19 +1,49 @@
 RSpec.describe 'DELETE /api/recipes/:id', type: :request do
   subject { response }
   let!(:recipe) { create(:recipe) }
+  let(:user) { create(:user) }
+  let(:credentials) { user.create_new_auth_token }
   describe 'successfully' do
-    before do
-      delete "/api/recipes/#{recipe.id}"
+    describe 'as an authenticated user' do
+      before do
+        delete "/api/recipes/#{recipe.id}", headers: credentials
+      end
+
+      it { is_expected.to have_http_status :accepted }
+
+      it 'is expected to respond with a message' do
+        expect(response_json['message']).to eq 'Your recipe has been deleted!'
+      end
+
+      it 'is expected to have the recipe deleted from the DB' do
+        expect { Recipe.find(recipe.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
+  end
 
-    it { is_expected.to have_http_status :accepted }
+  describe 'unsuccessfully' do
+    describe 'as an authenticated user' do
+      before do
+        delete "/api/recipes/ASJDOSAIJOIJ", headers: credentials
+      end
 
-    it 'is expected to respond with a message' do
-      expect(response_json['message']).to eq 'Your recipe has been deleted!'
+      it { is_expected.to have_http_status :not_found }
+
+      it 'is expected to respond with an error message' do
+        expect(response_json['message']).to eq 'The recipe cannot be found'
+      end
     end
+    
+    describe 'as an anonymous user' do
+      before do
+        delete "/api/recipes/#{recipe.id}", headers: nil
+      end
 
-    it 'is expected to have the recipe deleted from the DB' do
-      expect(Recipe.find(recipe.id)).to raise_error(ActiveRecord::RecordNotFound)
+      it { is_expected.to have_http_status :unauthorized }
+
+      it 'is expected to respond with a message' do
+        expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
+      end
     end
   end
 end

--- a/spec/requests/api/recipes/delete_spec.rb
+++ b/spec/requests/api/recipes/delete_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'DELETE /api/recipes/:id', type: :request do
+  subject { response }
+  let!(:recipe) { create(:recipe) }
+  describe 'successfully' do
+    before do
+      delete "/api/recipes/#{recipe.id}"
+    end
+
+    it { is_expected.to have_http_status :accepted }
+
+    it 'is expected to respond with a message' do
+      expect(response_json['message']).to eq 'Your recipe has been deleted!'
+    end
+
+    it 'is expected to have the recipe deleted from the DB' do
+      expect(Recipe.find(recipe.id)).to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/requests/api/recipes/delete_spec.rb
+++ b/spec/requests/api/recipes/delete_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'DELETE /api/recipes/:id', type: :request do
       it { is_expected.to have_http_status :not_found }
 
       it 'is expected to respond with an error message' do
-        expect(response_json['message']).to eq 'The recipe cannot be found'
+        expect(response_json['message']).to eq 'Recipe not found'
       end
     end
     

--- a/spec/requests/api/recipes/show_spec.rb
+++ b/spec/requests/api/recipes/show_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'GET/api/recipes/:id', type: :request do
+RSpec.describe 'GET /api/recipes/:id', type: :request do
   describe 'successfully' do
     let!(:ingredient1) {  create(:ingredient, { name: 'sugar' }) }
     let!(:ingredient2) { create(:ingredient, { name: 'milk' }) }


### PR DESCRIPTION
**This PR contains**

- add destroy route
- add request spec for delete_recipe
- add request spec for recipe delete action happy and sad path
- add destroy method in recipes controller

https://www.pivotaltracker.com/story/show/181164009

@giacoletti @Mljungho @elvitak 