### PR TITLE
Api provides an endpoint for list of ingredients

### DIFF
--- a/app/controllers/api/ingredients_controller.rb
+++ b/app/controllers/api/ingredients_controller.rb
@@ -1,0 +1,6 @@
+class Api::IngredientsController < ApplicationController
+  def index
+    ingredients = Ingredient.all
+    render json: ingredients, each_serializer: Ingredient::IndexSerializer
+  end
+end

--- a/app/serializers/ingredient/index_serializer.rb
+++ b/app/serializers/ingredient/index_serializer.rb
@@ -1,0 +1,3 @@
+class Ingredient::IndexSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
     resources :recipes, only: %i[index show create update destroy]
+    resources :ingredients, only: [:index]
   end
 end

--- a/spec/factories/ingredients.rb
+++ b/spec/factories/ingredients.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :ingredient do
-    name { 'sugar' }
+    name { Faker::Food.ingredient }
   end
 end

--- a/spec/requests/api/ingredients/index_spec.rb
+++ b/spec/requests/api/ingredients/index_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe 'GET /api/ingredients', type: :request do
+  subject { response }
+
+  let!(:spaghetti) { create(:ingredient, name: 'Spaghetti') }
+  let!(:egg) { create(:ingredient, name: 'Egg') }
+  let!(:flour) { create(:ingredient, name: 'Flour') }
+
+  describe 'successfully' do
+    before do
+      get '/api/ingredients'
+    end
+
+    it { is_expected.to have_http_status :ok }
+
+    it 'is expected to respond with a collection of 3 ingredients' do
+      expect(response_json['ingredients'].length).to eq 3
+    end
+
+    it 'is expected to respond with Spaghetti ingredient' do
+      expect(response_json['ingredients'].select do |ingredient|
+               ingredient['name'] == spaghetti.name
+             end).to eq [{ 'id' => spaghetti.id, 'name' => spaghetti.name }]
+    end
+  end
+end

--- a/spec/requests/api/ingredients/index_spec.rb
+++ b/spec/requests/api/ingredients/index_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe 'GET /api/ingredients', type: :request do
   subject { response }
 
-  let!(:spaghetti) { create(:ingredient, name: 'Spaghetti') }
-  let!(:egg) { create(:ingredient, name: 'Egg') }
-  let!(:flour) { create(:ingredient, name: 'Flour') }
+  let!(:ingredients) { create_list(:ingredient, 20) }
 
   describe 'successfully' do
     before do
@@ -12,14 +10,12 @@ RSpec.describe 'GET /api/ingredients', type: :request do
 
     it { is_expected.to have_http_status :ok }
 
-    it 'is expected to respond with a collection of 3 ingredients' do
-      expect(response_json['ingredients'].length).to eq 3
+    it 'is expected to respond with a collection of 20 ingredients' do
+      expect(response_json['ingredients'].count).to eq 20
     end
 
-    it 'is expected to respond with Spaghetti ingredient' do
-      expect(response_json['ingredients'].select do |ingredient|
-               ingredient['name'] == spaghetti.name
-             end).to eq [{ 'id' => spaghetti.id, 'name' => spaghetti.name }]
+    it 'is expected to respond with ingredients names' do
+      expect(response_json['ingredients'].first['name']).to_not eq nil
     end
   end
 end

--- a/spec/requests/api/ingredients/index_spec.rb
+++ b/spec/requests/api/ingredients/index_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'GET /api/ingredients', type: :request do
   subject { response }
 
-  let!(:ingredients) { create_list(:ingredient, 20) }
+  let!(:ingredient) { create(:ingredient) }
 
   describe 'successfully' do
     before do
@@ -10,12 +10,8 @@ RSpec.describe 'GET /api/ingredients', type: :request do
 
     it { is_expected.to have_http_status :ok }
 
-    it 'is expected to respond with a collection of 20 ingredients' do
-      expect(response_json['ingredients'].count).to eq 20
-    end
-
-    it 'is expected to respond with ingredients names' do
-      expect(response_json['ingredients'].first['name']).to_not eq nil
+    it 'is expected to respond with a collection of 1 ingredient' do
+      expect(response_json['ingredients'].count).to eq 1
     end
   end
 end

--- a/spec/requests/api/ingredients/index_spec.rb
+++ b/spec/requests/api/ingredients/index_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'GET /api/ingredients', type: :request do
   subject { response }
 
-  let!(:ingredient) { create(:ingredient) }
+  let!(:ingredients) { create_list(:ingredient, 20) }
 
   describe 'successfully' do
     before do
@@ -10,8 +10,8 @@ RSpec.describe 'GET /api/ingredients', type: :request do
 
     it { is_expected.to have_http_status :ok }
 
-    it 'is expected to respond with a collection of 1 ingredient' do
-      expect(response_json['ingredients'].count).to eq 1
+    it 'is expected to respond with a collection of 20 ingredients' do
+      expect(response_json['ingredients'].count).to eq 20
     end
   end
 end

--- a/spec/serializers/ingredients/index_serializer_spec.rb
+++ b/spec/serializers/ingredients/index_serializer_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Ingredient::IndexSerializer, type: :serializer do
+  let(:ingredients) { create_list(:ingredient, 20) }
+
+  let(:serialization) do
+    ActiveModelSerializers::SerializableResource.new(
+      ingredients,
+      each_serializer: described_class
+    )
+  end
+
+  subject { JSON.parse(serialization.to_json) }
+
+  it 'is expected to wrap data in a key reflecting the resource name' do
+    expect(subject.keys).to match ['ingredients']
+  end
+
+  it 'is expected to include relevant keys' do
+    expected_keys = %w[id name]
+    expect(subject['ingredients'].first.keys).to match expected_keys
+  end
+
+  it 'is expected to contain keys with values of specific data types' do
+    expect(subject['ingredients'].first).to match(
+      {
+        'id' => an_instance_of(Integer),
+        'name' => an_instance_of(String)
+      }
+    )
+  end
+end

--- a/spec/serializers/ingredients/index_serializer_spec.rb
+++ b/spec/serializers/ingredients/index_serializer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Ingredient::IndexSerializer, type: :serializer do
-  let(:ingredients) { create_list(:ingredient, 20) }
+  let(:ingredients) { create_list(:ingredient, 1) }
 
   let(:serialization) do
     ActiveModelSerializers::SerializableResource.new(


### PR DESCRIPTION
### This PR contains:
- add request spec for ingredients index action
- add ingredient index serializer spec
- create ingredients controller with index method
- create ingredient index serializer
- add /api/ingredients namespace with index route

@Mljungho @elvitak @DefyCab

[Pivotal Tracker Feature](https://www.pivotaltracker.com/story/show/181241121)