### PR TITLE
Api provides recipe owner email in show response to display Edit button

### DIFF
--- a/app/serializers/recipe/show_serializer.rb
+++ b/app/serializers/recipe/show_serializer.rb
@@ -1,8 +1,12 @@
 class Recipe::ShowSerializer < ActiveModel::Serializer
-  attributes :id, :name, :instructions, :ingredients, :created_at
+  attributes :id, :name, :instructions, :ingredients, :created_at, :owner
   has_many :ingredients, serializer: Ingredient::ShowSerializer
 
   def created_at
     object.created_at.to_formatted_s(:long)
+  end
+
+  def owner
+    object.user.email
   end
 end

--- a/spec/serializers/recipe/show_serializer_spec.rb
+++ b/spec/serializers/recipe/show_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Recipe::ShowSerializer, type: :serializer do
   end
 
   it 'is expected to include relevant keys' do
-    expected_keys = %w[id name instructions ingredients created_at]
+    expected_keys = %w[id name instructions ingredients created_at owner]
     expect(subject['recipe'].keys).to match expected_keys
   end
 
@@ -25,7 +25,8 @@ RSpec.describe Recipe::ShowSerializer, type: :serializer do
         'name' => an_instance_of(String),
         'instructions' => an_instance_of(String),
         'ingredients' => an_instance_of(Array),
-        'created_at' => an_instance_of(String)
+        'created_at' => an_instance_of(String),
+        'owner' => an_instance_of(String)
       }
     )
   end


### PR DESCRIPTION
### THIS PR CONTAINS: 

- Aditional information in serializer. Adding owner in order to verify user is owner of recipe in front end.

https://www.pivotaltracker.com/story/show/181244482

@giacoletti @DefyCab @elvitak 