### PR TITLE
Modify index serializer to only show first 100 character

### DIFF
--- a/app/serializers/recipe/index_serializer.rb
+++ b/app/serializers/recipe/index_serializer.rb
@@ -1,5 +1,5 @@
 class Recipe::IndexSerializer < ActiveModel::Serializer
-  attributes :id, :image, :name, :instructions, :created_at, :updated_at, :user, :forks_count
+  attributes :id, :image, :name, :lede, :instructions, :created_at, :updated_at, :user, :forks_count
 
   def created_at
     object.created_at.to_formatted_s(:long)
@@ -15,5 +15,9 @@ class Recipe::IndexSerializer < ActiveModel::Serializer
 
   def image
     object.image_serialized
+  end
+
+  def lede
+    object.instructions[0, 100]
   end
 end

--- a/spec/requests/api/recipes/index_spec.rb
+++ b/spec/requests/api/recipes/index_spec.rb
@@ -22,8 +22,11 @@ RSpec.describe 'GET /api/recipes', type: :request do
       it 'is expected to respond the with right instructions' do
         expect(response_json['recipes'].first['instructions']).to_not eq nil
       end
-    end
 
+      it 'is expected to respond with a recipe lede' do
+        expect(response_json['recipes'].first['lede']).to_not eq nil
+      end
+    end
     describe 'filter recipes by user' do
       before do
         get '/api/recipes', params: { user: user.email }

--- a/spec/serializers/recipe/index_serializer_spec.rb
+++ b/spec/serializers/recipe/index_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Recipe::IndexSerializer, type: :serializer do
     expect(subject.keys).to match ['recipes']
   end
   it 'is expected to include relevant keys' do
-    expected_keys = %w[id image name instructions created_at updated_at user forks_count]
+    expected_keys = %w[id image name lede instructions created_at updated_at user forks_count]
     expect(subject['recipes'].first.keys).to match expected_keys
   end
   it 'is expected to contain keys with values of specific data types' do
@@ -23,6 +23,7 @@ RSpec.describe Recipe::IndexSerializer, type: :serializer do
         'id' => an_instance_of(Integer),
         'image' => an_instance_of(String),
         'name' => an_instance_of(String),
+        'lede' => an_instance_of(String),
         'instructions' => an_instance_of(String),
         'created_at' => an_instance_of(String),
         'updated_at' => an_instance_of(String),


### PR DESCRIPTION
**This PR contains**

- add lede to recipe inex serializer that show 100 first characthers of instructions
- update index request spec and index serializer spec

https://www.pivotaltracker.com/story/show/181265983