### PR TITLE
Internal Server Error when creating a Recipe without an image

### DIFF
--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -40,7 +40,11 @@ class Api::RecipesController < ApplicationController
   private
 
   def validate_params_presence
-    render_error('Recipe is missing', :unprocessable_entity) if params[:recipe].nil?
+    if params[:recipe].nil?
+      render_error('Recipe is missing', :unprocessable_entity)
+    elsif params[:recipe][:image].nil? && params[:recipe][:fork].nil?
+      render_error('A recipe must have an image', :unprocessable_entity)
+    end
   end
 
   def find_recipe

--- a/spec/requests/api/recipes/create_spec.rb
+++ b/spec/requests/api/recipes/create_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe 'POST /api/recipes', type: :request do
               instructions: 'Mix and shake it',
               ingredients_attributes: [
                 { ingredient_id: rice.id, unit: 'gram', amount: '2000' }
-              ]
+              ],
+              image: 'data:image/image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAAEBCAMAAAD1kWivAAADAFB'
             }
           }, headers: credentials
         end
@@ -114,7 +115,8 @@ RSpec.describe 'POST /api/recipes', type: :request do
               name: 'Spaghetti bolognese',
               ingredients_attributes: [
                 { ingredient_id: rice.id, unit: 'gram', amount: '2000' }
-              ]
+              ],
+              image: 'data:image/image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAAEBCAMAAAD1kWivAAADAFB'
             }
           }, headers: credentials
         end
@@ -123,6 +125,26 @@ RSpec.describe 'POST /api/recipes', type: :request do
 
         it 'is expected to respond with an error message' do
           expect(response_json['message']).to eq "Instructions can't be blank"
+        end
+      end
+
+      describe 'due to missing recipe image' do
+        before do
+          post '/api/recipes', params: {
+            recipe: {
+              name: 'Fried rice with kimchi',
+              instructions: 'Mix and shake it',
+              ingredients_attributes: [
+                { ingredient_id: rice.id, unit: 'gram', amount: '200' }
+              ]
+            }
+          }, headers: credentials
+        end
+
+        it { is_expected.to have_http_status :unprocessable_entity }
+
+        it 'is expected to respond with an error message' do
+          expect(response_json['message']).to eq 'A recipe must have an image'
         end
       end
 


### PR DESCRIPTION
### This PR contains:
- add to request spec for recipe create action check if recipe image is nil, is expected an error message
- expand validate params presence in recipes controller, for create method

@Mljungho @elvitak @DefyCab 

[Pivotal Tracker Chore](https://www.pivotaltracker.com/story/show/181322176)