### PR TITLE
Image doesn't appear on forked recipe

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -27,6 +27,12 @@ class Recipe < ApplicationRecord
                                          unit: ingredient.unit)
       end
     end
+    duplicated_image = image.blob.download
+    forked_recipe.image.attach(
+      io: StringIO.new(duplicated_image),
+      filename: image.filename.to_s,
+      content_type: image.content_type
+    )
     update(forks_count: forks_count + 1)
     forked_recipe
   end

--- a/spec/requests/api/recipes/create_spec.rb
+++ b/spec/requests/api/recipes/create_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'POST /api/recipes', type: :request do
             }
           }, headers: new_credentials
           @recipe = Recipe.find(original_recipe.id)
+          @forked_recipe = Recipe.last
         end
 
         it { is_expected.to have_http_status :created }
@@ -71,6 +72,14 @@ RSpec.describe 'POST /api/recipes', type: :request do
 
         it 'is expected to have original recipe forks count up to 1' do
           expect(@recipe.forks_count).to eq 1
+        end
+
+        it 'is expected to have duplicated image attached' do
+          expect(@forked_recipe.image).to be_attached
+        end
+
+        it 'is expected to have new owner to the forked recipe' do
+          expect(@forked_recipe.user.name).to eq new_user.name
         end
       end
     end


### PR DESCRIPTION
### This PR contains:
- add to request spec for Recipe create action check for duplicated image to be attached and to have the new owner set
- duplicate image and attach it to the forked recipe in Recipe model

@Mljungho @elvitak @DefyCab 

[Pivotal Tracker Chore](https://www.pivotaltracker.com/story/show/181321997)